### PR TITLE
🤖 Add authors and contributors to Practice Exercises

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -13,7 +13,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "njbbaer",
     "prbroadfoot",
     "raadler",

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,6 +1,24 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "boddhisattva",
+    "budmc29",
+    "cadwallion",
+    "connermcd",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "njbbaer",
+    "prbroadfoot",
+    "raadler",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "accumulate.rb"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": [],
+  "authors": [
+    "monkbroc"
+  ],
+  "contributors": [
+    "bmulvihill",
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kickinbahk",
+    "kotp",
+    "kytrinyx",
+    "PatrickMcSweeny",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "acronym.rb"

--- a/exercises/practice/affine-cipher/.meta/config.json
+++ b/exercises/practice/affine-cipher/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Create an implementation of the Affine cipher, an ancient encryption algorithm from the Middle East.",
-  "authors": [],
+  "authors": [
+    "guygastineau"
+  ],
+  "contributors": [
+    "cadwallion",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "affine_cipher.rb"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
-  "authors": [],
+  "authors": [
+    "sebarmano"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "tommyschaefer",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "all_your_base.rb"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -12,7 +12,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "mikegehard",
     "pendletons",
     "tryantwit"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "ajwann",
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "mikegehard",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "allergies.rb"

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Write a function to solve alphametics puzzles.",
-  "authors": [],
+  "authors": [
+    "repinel"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mattkimmel",
+    "n8chz",
+    "NeimadTL",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "alphametics.rb"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,6 +1,28 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "fredrb",
+    "henrik",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jmay",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "markijbema",
+    "martinsvalin",
+    "pgaspar",
+    "pvcarrera",
+    "sbagdat",
+    "Thrillberg",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "anagram.rb"

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -14,7 +14,6 @@
     "jmay",
     "jpotts244",
     "kotp",
-    "mambocab",
     "markijbema",
     "martinsvalin",
     "pgaspar",

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,6 +1,13 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
-  "authors": [],
+  "authors": [
+    "Tuxified"
+  ],
+  "contributors": [
+    "guygastineau",
+    "iHiD",
+    "kotp"
+  ],
   "files": {
     "solution": [
       "armstrong_numbers.rb"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "guygastineau",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "atbash_cipher.rb"

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -11,7 +11,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "pendletons",
     "tryantwit"
   ],

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Produce the lyrics to that beloved classic, that field-trip favorite: 99 Bottles of Beer on the Wall.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "ccouzens",
+    "dkinzer",
+    "emcoding",
+    "henrik",
+    "hilary",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "beer_song.rb"

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -14,7 +14,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "pendletons",
     "tryantwit"
   ],

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -12,7 +12,6 @@
     "Insti",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "pendletons",
     "remcopeereboom",
     "Ryan1729",

--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Insert and search for numbers in a binary tree.",
-  "authors": [],
+  "authors": [
+    "vosechu"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "pendletons",
+    "remcopeereboom",
+    "Ryan1729",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "binary_search_tree.rb"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -13,7 +13,6 @@
     "Insti",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Implement a binary search algorithm.",
-  "authors": [],
+  "authors": [
+    "fluxusfrequency"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "dkinzer",
+    "fredrb",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "binary_search.rb"

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -14,7 +14,6 @@
     "jpotts244",
     "kickinbahk",
     "kotp",
-    "mambocab",
     "pendletons",
     "samjonester",
     "scottcrawford03",

--- a/exercises/practice/binary/.meta/config.json
+++ b/exercises/practice/binary/.meta/config.json
@@ -1,6 +1,26 @@
 {
   "blurb": "Convert a binary number, represented as a string (e.g. '101010'), to its decimal equivalent using first principles",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "bmulvihill",
+    "budmc29",
+    "cadwallion",
+    "casto101",
+    "henrik",
+    "hilary",
+    "Insti",
+    "jpotts244",
+    "kickinbahk",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "samjonester",
+    "scottcrawford03",
+    "tommyschaefer",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "binary.rb"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -19,7 +19,6 @@
     "jpotts244",
     "koriroys",
     "kotp",
-    "mambocab",
     "markijbema",
     "martyhines",
     "Nadrioc",

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,6 +1,38 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "ajwann",
+    "austinlyons",
+    "avit",
+    "budmc29",
+    "cadwallion",
+    "copiousfreetime",
+    "doncruse",
+    "Gaelan",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jmay",
+    "jpotts244",
+    "koriroys",
+    "kotp",
+    "mambocab",
+    "markijbema",
+    "martyhines",
+    "Nadrioc",
+    "Nerian",
+    "PatrickMcSweeny",
+    "Pavling",
+    "prathamesh-sonpatki",
+    "seeflanigan",
+    "shingara",
+    "toddsiegel",
+    "Tonkpils",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "bob.rb"

--- a/exercises/practice/book-store/.meta/config.json
+++ b/exercises/practice/book-store/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "To try and encourage more sales of different books from a popular 5 book series, a bookshop has decided to offer discounts of multiple-book purchases.",
   "authors": [],
+  "contributors": [
+    "cadwallion",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "book_store.rb"

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Score a bowling game",
-  "authors": [],
+  "authors": [
+    "bernardoamc"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "gchan",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "NeimadTL",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "bowling.rb"

--- a/exercises/practice/change/.meta/config.json
+++ b/exercises/practice/change/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Correctly determine change to be given using the least number of coins",
-  "authors": [],
+  "authors": [
+    "adimasuhid"
+  ],
+  "contributors": [
+    "cadwallion",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "njbbaer",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "change.rb"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "A data structure that uses a single, fixed-size buffer as if it were connected end-to-end.",
-  "authors": [],
+  "authors": [
+    "anthonygreen"
+  ],
+  "contributors": [
+    "budmc29",
+    "dalexj",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "julianandrews",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "circular_buffer.rb"

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -13,7 +13,6 @@
     "julianandrews",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "pendletons",
     "tryantwit"
   ],

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -14,7 +14,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "pendletons",
     "pgaspar",
     "tryantwit",

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -1,6 +1,25 @@
 {
   "blurb": "Implement a clock that handles times without dates.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "cadwallion",
+    "guygastineau",
+    "henrik",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "pgaspar",
+    "tryantwit",
+    "wvmitchell"
+  ],
   "files": {
     "solution": [
       "clock.rb"

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
-  "authors": [],
+  "authors": [
+    "Insti"
+  ],
+  "contributors": [
+    "ajwann",
+    "budmc29",
+    "cadwallion",
+    "iHiD",
+    "jpotts244",
+    "kotp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "collatz_conjecture.rb"

--- a/exercises/practice/complex-numbers/.meta/config.json
+++ b/exercises/practice/complex-numbers/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Implement complex numbers.",
-  "authors": [],
+  "authors": [
+    "m1kal"
+  ],
+  "contributors": [
+    "cadwallion",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mftaff",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "complex_numbers.rb"

--- a/exercises/practice/connect/.meta/config.json
+++ b/exercises/practice/connect/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Compute the result for a game of Hex / Polygon",
-  "authors": [],
+  "authors": [
+    "jonatas"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "NeimadTL",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "connect.rb"

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -13,7 +13,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/crypto-square/.meta/config.json
+++ b/exercises/practice/crypto-square/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Implement the classic method for composing secret messages called a square code.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alexkalderimis",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "crypto_square.rb"

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,6 +1,25 @@
 {
   "blurb": "Create a custom set type.",
-  "authors": [],
+  "authors": [
+    "fluxusfrequency"
+  ],
+  "contributors": [
+    "aarti",
+    "alxndr",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "mamenama",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "custom_set.rb"

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -15,7 +15,6 @@
     "jpotts244",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "mamenama",
     "pendletons",
     "tryantwit"

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
-  "authors": [],
+  "authors": [
+    "Thrillberg"
+  ],
+  "contributors": [
+    "sas2job"
+  ],
   "files": {
     "solution": [
       "darts.rb"

--- a/exercises/practice/diamond/.meta/config.json
+++ b/exercises/practice/diamond/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Given a letter, print a diamond starting with 'A' with the supplied letter at the widest point.",
-  "authors": [],
+  "authors": [
+    "cloudleo"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "diamond.rb"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "bjmllr",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "landongrindheim",
+    "mambocab",
+    "mike-hewitson",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "difference_of_squares.rb"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -14,7 +14,6 @@
     "jpotts244",
     "kotp",
     "landongrindheim",
-    "mambocab",
     "mike-hewitson",
     "tryantwit"
   ],

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Make a chain of dominoes.",
-  "authors": [],
+  "authors": [
+    "petertseng"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "NeimadTL",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "dominoes.rb"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "ajwann",
+    "budmc29",
+    "cadwallion",
+    "etrepum",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "etl.rb"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -13,7 +13,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "pendletons",
     "pgaspar",
     "tryantwit"

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Take a nested list and return a single list with all values except nil/null",
-  "authors": [],
+  "authors": [
+    "dougtebay"
+  ],
+  "contributors": [
+    "ajwann",
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "snoozer05",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "flatten_array.rb"

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,6 +1,25 @@
 {
   "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alexbrinkman",
+    "alxndr",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "fluxusfrequency",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kickinbahk",
+    "kotp",
+    "mambocab",
+    "McEileen",
+    "Rojo",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "food_chain.rb"

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -15,7 +15,6 @@
     "Insti",
     "kickinbahk",
     "kotp",
-    "mambocab",
     "McEileen",
     "Rojo",
     "tryantwit"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,6 +1,26 @@
 {
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "benoittgt",
+    "budmc29",
+    "cadwallion",
+    "chrisvroberts",
+    "dkinzer",
+    "haines",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kickinbahk",
+    "kotp",
+    "mambocab",
+    "mike-hewitson",
+    "sambev",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "gigasecond.rb"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -16,7 +16,6 @@
     "jpotts244",
     "kickinbahk",
     "kotp",
-    "mambocab",
     "mike-hewitson",
     "sambev",
     "tryantwit"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,6 +1,24 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "henrik",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "JikkuJose",
+    "kotp",
+    "mambocab",
+    "markijbema",
+    "notapatch",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "grade_school.rb"

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -14,7 +14,6 @@
     "Insti",
     "JikkuJose",
     "kotp",
-    "mambocab",
     "markijbema",
     "notapatch",
     "tryantwit"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -11,7 +11,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "StevenXL",
     "tommyschaefer",
     "tryantwit"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "StevenXL",
+    "tommyschaefer",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "grains.rb"

--- a/exercises/practice/grep/.meta/config.json
+++ b/exercises/practice/grep/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Search a file for lines matching a regular expression pattern. Return the line number and contents of each matching line.",
-  "authors": [],
+  "authors": [
+    "pgaspar"
+  ],
+  "contributors": [
+    "iHiD",
+    "kotp"
+  ],
   "files": {
     "solution": [
       "grep.rb"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -15,7 +15,6 @@
     "kickinbahk",
     "kotp",
     "KyleMartin901",
-    "mambocab",
     "mike-hewitson",
     "mjansen401",
     "pgaspar",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,6 +1,29 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "Eventlessdrop",
+    "glamouracademy",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kickinbahk",
+    "kotp",
+    "KyleMartin901",
+    "mambocab",
+    "mike-hewitson",
+    "mjansen401",
+    "pgaspar",
+    "siakaramalegos",
+    "StevenXL",
+    "trayo",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "hamming.rb"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,6 +1,28 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": [],
+  "authors": [
+    "ramonh"
+  ],
+  "contributors": [
+    "abartov",
+    "bgrabow",
+    "budmc29",
+    "gilmatic",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "Kosmas",
+    "kotp",
+    "kytrinyx",
+    "mike-hewitson",
+    "NeimadTL",
+    "sivabudh",
+    "skeskali",
+    "thejoycekung",
+    "trayo",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "hello_world.rb"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Convert a hexadecimal number, represented as a string (e.g. \"10af8c\"), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "hexadecimal.rb"

--- a/exercises/practice/hexadecimal/.meta/config.json
+++ b/exercises/practice/hexadecimal/.meta/config.json
@@ -9,7 +9,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/high-scores/.meta/config.json
+++ b/exercises/practice/high-scores/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Manage a player's High Score list",
-  "authors": [],
+  "authors": [
+    "pgaspar"
+  ],
+  "contributors": [
+    "emcoding",
+    "iHiD",
+    "Insti",
+    "kotp"
+  ],
   "files": {
     "solution": [
       "high_scores.rb"

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -9,7 +9,6 @@
     "hilary",
     "Insti",
     "kotp",
-    "mambocab",
     "pendletons",
     "tryantwit"
   ],

--- a/exercises/practice/house/.meta/config.json
+++ b/exercises/practice/house/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Output the nursery rhyme 'This is the House that Jack Built'.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "etrepum",
+    "hilary",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "house.rb"

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Check if a given string is a valid ISBN-10 number.",
-  "authors": [],
+  "authors": [
+    "bmkiefer"
+  ],
+  "contributors": [
+    "cadwallion",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "isbn_verifier.rb"

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Determine if a word or phrase is an isogram.",
-  "authors": [],
+  "authors": [
+    "alliesauce"
+  ],
+  "contributors": [
+    "bmkiefer",
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "PatrickMcSweeny",
+    "pgaspar",
+    "securitylater",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "isogram.rb"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Given a diagram, determine which plants each child in the kindergarten class is responsible for.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alexpchin",
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "kindergarten_garden.rb"

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -11,7 +11,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,6 +1,24 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "chrisvroberts",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "petertseng",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "largest_series_product.rb"

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -13,7 +13,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "pendletons",
     "petertseng",
     "pgaspar",

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,6 +1,27 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "Gaelan",
+    "henrik",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jcasimir",
+    "jmay",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "markijbema",
+    "mike-hewitson",
+    "NeimadTL",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "leap.rb"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -16,7 +16,6 @@
     "jmay",
     "jpotts244",
     "kotp",
-    "mambocab",
     "markijbema",
     "mike-hewitson",
     "NeimadTL",

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -14,7 +14,6 @@
     "kewlar",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "pendletons",
     "ryanplusplus",
     "tryantwit"

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,6 +1,24 @@
 {
   "blurb": "Implement a doubly linked list",
-  "authors": [],
+  "authors": [
+    "vosechu"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "dkinzer",
+    "etrepum",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kewlar",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "pendletons",
+    "ryanplusplus",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "linked_list.rb"

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Implement basic list operations",
-  "authors": [],
+  "authors": [
+    "rhoprhh"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "srabuini",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "list_ops.rb"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "dalexj",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "luhn.rb"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -12,7 +12,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "pgaspar",
     "tryantwit"
   ],

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
-  "authors": [],
+  "authors": [
+    "moofkit"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "ebiven",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "pgaspar",
+    "SleeplessByte",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "matching_brackets.rb"

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -10,7 +10,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/matrix/.meta/config.json
+++ b/exercises/practice/matrix/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Given a string representing a matrix of numbers, return the rows and columns of that matrix.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "coolbrg",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "matrix.rb"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Calculate the date of meetups.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "ajwann",
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kangkyu",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "meetup.rb"

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -13,7 +13,6 @@
     "jpotts244",
     "kangkyu",
     "kotp",
-    "mambocab",
     "pendletons",
     "tryantwit"
   ],

--- a/exercises/practice/microwave/.meta/config.json
+++ b/exercises/practice/microwave/.meta/config.json
@@ -1,5 +1,11 @@
 {
-  "authors": [],
+  "authors": [
+    "gatorjuice"
+  ],
+  "contributors": [
+    "aleksandrilyin",
+    "petertseng"
+  ],
   "files": {
     "solution": [
       "microwave.rb"

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Add the numbers to a minesweeper board",
-  "authors": [],
+  "authors": [
+    "fluxusfrequency"
+  ],
+  "contributors": [
+    "abeger",
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "minesweeper.rb"

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -12,7 +12,6 @@
     "Insti",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Given a number n, determine what the nth prime is.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "bernardoamc",
+    "budmc29",
+    "cadwallion",
+    "clettenberg",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "nth_prime.rb"

--- a/exercises/practice/nth-prime/.meta/config.json
+++ b/exercises/practice/nth-prime/.meta/config.json
@@ -14,7 +14,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "pendletons",
     "tryantwit"
   ],

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -11,7 +11,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "nikhiltaneja",
     "rcuhljr",
     "tryantwit"

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "fluxusfrequency",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "nikhiltaneja",
+    "rcuhljr",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "nucleotide_count.rb"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -14,7 +14,6 @@
     "jpotts244",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "pendletons",
     "pgaspar",
     "tryantwit"

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -1,6 +1,24 @@
 {
   "blurb": "Given a 3 x 4 grid of pipes, underscores, and spaces, determine which number is represented, or whether it is garbled.",
-  "authors": [],
+  "authors": [
+    "vosechu"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "emcoding",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "pendletons",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "ocr_numbers.rb"

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Convert a octal number, represented as a string (e.g. '1735263'), to its decimal equivalent using first principles (i.e. no, you may not use built-in or external libraries to accomplish the conversion).",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dpneumo",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "octal.rb"

--- a/exercises/practice/octal/.meta/config.json
+++ b/exercises/practice/octal/.meta/config.json
@@ -10,7 +10,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -12,7 +12,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "markijbema",
     "tryantwit"
   ],

--- a/exercises/practice/palindrome-products/.meta/config.json
+++ b/exercises/practice/palindrome-products/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Detect palindrome products in a given range.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "dalexj",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "markijbema",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "palindrome_products.rb"

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": [],
+  "authors": [
+    "Cohen-Carlisle"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "rpalo",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "pangram.rb"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "pascals_triangle.rb"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -10,7 +10,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Determine if a number is perfect, abundant, or deficient based on Nicomachus' (60 - 120 CE) classification scheme for positive integers.",
-  "authors": [],
+  "authors": [
+    "chintas1"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "gchan",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "perfect_numbers.rb"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,6 +1,28 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "dalexj",
+    "dkinzer",
+    "drueck",
+    "fluxusfrequency",
+    "henrik",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kchien",
+    "kotp",
+    "mambocab",
+    "mjansen401",
+    "PatrickMcSweeny",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "phone_number.rb"

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -17,7 +17,6 @@
     "jpotts244",
     "kchien",
     "kotp",
-    "mambocab",
     "mjansen401",
     "PatrickMcSweeny",
     "pgaspar",

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -14,7 +14,6 @@
     "jpotts244",
     "kotp",
     "kvsm",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Implement a program that translates from English to Pig Latin",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "dpneumo",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kvsm",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "pig_latin.rb"

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -10,7 +10,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "meaganewaller",
     "tryantwit"
   ],

--- a/exercises/practice/point-mutations/.meta/config.json
+++ b/exercises/practice/point-mutations/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "meaganewaller",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "point_mutations.rb"

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Pick the best hand(s) from a list of poker hands.",
-  "authors": [],
+  "authors": [
+    "fabienalbi"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "moveson",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "poker.rb"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Compute the prime factors of a given natural number.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "joshgoebel",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "prime_factors.rb"

--- a/exercises/practice/prime-factors/.meta/config.json
+++ b/exercises/practice/prime-factors/.meta/config.json
@@ -11,7 +11,6 @@
     "Insti",
     "joshgoebel",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Translate RNA sequences into proteins.",
-  "authors": [],
+  "authors": [
+    "Teapane"
+  ],
+  "contributors": [
+    "budmc29",
+    "chrisvroberts",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "mamenama",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "protein_translation.rb"

--- a/exercises/practice/protein-translation/.meta/config.json
+++ b/exercises/practice/protein-translation/.meta/config.json
@@ -12,7 +12,6 @@
     "Insti",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "mamenama",
     "pendletons",
     "tryantwit"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -9,7 +9,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "notapatch",
     "pendletons",
     "tryantwit"

--- a/exercises/practice/proverb/.meta/config.json
+++ b/exercises/practice/proverb/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "For want of a horseshoe nail, a kingdom was lost, or so the saying goes. Output the full text of this proverbial rhyme.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "notapatch",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "proverb.rb"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dalexj",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "RiderSargent",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "pythagorean_triplet.rb"

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -11,7 +11,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "RiderSargent",
     "tryantwit"
   ],

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -15,7 +15,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "pendletons",
     "pgaspar",
     "samjonester",

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -1,6 +1,26 @@
 {
   "blurb": "Given the position of two queens on a chess board, indicate whether or not they are positioned so that they can attack each other.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "cadwallion",
+    "cored",
+    "dkinzer",
+    "henrik",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "pgaspar",
+    "samjonester",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "queen_attack.rb"

--- a/exercises/practice/rail-fence-cipher/.meta/config.json
+++ b/exercises/practice/rail-fence-cipher/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Implement encoding and decoding for the rail fence cipher.",
-  "authors": [],
+  "authors": [
+    "raysapida"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "emcoding",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "rail_fence_cipher.rb"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "bmulvihill",
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "mike-hewitson",
+    "notapatch",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "raindrops.rb"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -12,7 +12,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "mike-hewitson",
     "notapatch",
     "tryantwit"

--- a/exercises/practice/resistor-color-duo/.meta/config.json
+++ b/exercises/practice/resistor-color-duo/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a numeric value.",
-  "authors": [],
+  "authors": [
+    "pgaspar"
+  ],
+  "contributors": [
+    "iHiD",
+    "kotp"
+  ],
   "files": {
     "solution": [
       "resistor_color_duo.rb"

--- a/exercises/practice/resistor-color-trio/.meta/config.json
+++ b/exercises/practice/resistor-color-trio/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Convert color codes, as used on resistors, to a human-readable label.",
-  "authors": [],
+  "authors": [
+    "pgaspar"
+  ],
+  "contributors": [
+    "iHiD",
+    "kotp"
+  ],
   "files": {
     "solution": [
       "resistor_color_trio.rb"

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Convert a resistor band's color to its numeric representation",
-  "authors": [],
+  "authors": [
+    "pgaspar"
+  ],
+  "contributors": [
+    "iHiD",
+    "kotp"
+  ],
   "files": {
     "solution": [
       "resistor_color.rb"

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -17,7 +17,6 @@
     "jpotts244",
     "kickinbahk",
     "kotp",
-    "mambocab",
     "mhelmetag",
     "mike-hewitson",
     "NobbZ",

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,6 +1,30 @@
 {
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "cadwallion",
+    "Cohen-Carlisle",
+    "connorlay",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jmay",
+    "jpotts244",
+    "kickinbahk",
+    "kotp",
+    "mambocab",
+    "mhelmetag",
+    "mike-hewitson",
+    "NobbZ",
+    "pck",
+    "tryantwit",
+    "tylerferraro"
+  ],
   "files": {
     "solution": [
       "rna_transcription.rb"

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -12,7 +12,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "StevenXL",
     "tryantwit",
     "vitoreiji"

--- a/exercises/practice/robot-name/.meta/config.json
+++ b/exercises/practice/robot-name/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Manage robot factory settings.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "callahat",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "StevenXL",
+    "tryantwit",
+    "vitoreiji"
+  ],
   "files": {
     "solution": [
       "robot_name.rb"

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "tryantwit",
+    "vosechu"
+  ],
   "files": {
     "solution": [
       "robot_simulator.rb"

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -10,7 +10,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "pendletons",
     "tryantwit",
     "vosechu"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "boddhisattva",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "mike-hewitson",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "roman_numerals.rb"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -13,7 +13,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "mike-hewitson",
     "tryantwit"
   ],

--- a/exercises/practice/rotational-cipher/.meta/config.json
+++ b/exercises/practice/rotational-cipher/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.",
-  "authors": [],
+  "authors": [
+    "adimasuhid"
+  ],
+  "contributors": [
+    "cadwallion",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "njbbaer",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "rotational_cipher.rb"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Implement run-length encoding and decoding.",
-  "authors": [],
+  "authors": [
+    "Cohen-Carlisle"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "run_length_encoding.rb"

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -11,7 +11,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Detect saddle points in a matrix.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "etrepum",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "saddle_points.rb"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -13,7 +13,6 @@
     "kangkyu",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "pgaspar",
     "tommyschaefer",
     "tryantwit"

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
-  "authors": [],
+  "authors": [
+    "vosechu"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kangkyu",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "pgaspar",
+    "tommyschaefer",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "say.rb"

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -13,7 +13,6 @@
     "Insti",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "srabuini",
     "tryantwit"
   ],

--- a/exercises/practice/scale-generator/.meta/config.json
+++ b/exercises/practice/scale-generator/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Generate musical scales, given a starting note and a set of intervals. ",
-  "authors": [],
+  "authors": [
+    "fluxusfrequency"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "chrisvroberts",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "srabuini",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "scale_generator.rb"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -10,7 +10,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "scrabble_score.rb"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Given a decimal number, convert it to the appropriate sequence of events for a secret handshake.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "sjwarner-bp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "secret_handshake.rb"

--- a/exercises/practice/secret-handshake/.meta/config.json
+++ b/exercises/practice/secret-handshake/.meta/config.json
@@ -10,7 +10,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "sjwarner-bp",
     "tryantwit"
   ],

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -11,7 +11,6 @@
     "Insti",
     "jeporcher",
     "kotp",
-    "mambocab",
     "mikegehard",
     "pgaspar",
     "stevensonmt",

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "emcoding",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jeporcher",
+    "kotp",
+    "mambocab",
+    "mikegehard",
+    "pgaspar",
+    "stevensonmt",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "series.rb"

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -12,7 +12,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "pvcarrera",
     "tryantwit"
   ],

--- a/exercises/practice/sieve/.meta/config.json
+++ b/exercises/practice/sieve/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Use the Sieve of Eratosthenes to find all the primes from 2 up to a given number.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "pvcarrera",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "sieve.rb"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -12,7 +12,6 @@
     "Insti",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "markijbema",
     "snoozer05",
     "tryantwit"

--- a/exercises/practice/simple-cipher/.meta/config.json
+++ b/exercises/practice/simple-cipher/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Implement a simple shift cipher like Caesar and a more secure substitution cipher",
-  "authors": [],
+  "authors": [
+    "vosechu"
+  ],
+  "contributors": [
+    "budmc29",
+    "dalexj",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "markijbema",
+    "snoozer05",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "simple_cipher.rb"

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -16,7 +16,6 @@
     "jpotts244",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "tryantwit",
     "zvkemp"
   ],

--- a/exercises/practice/simple-linked-list/.meta/config.json
+++ b/exercises/practice/simple-linked-list/.meta/config.json
@@ -1,6 +1,25 @@
 {
   "blurb": "Write a simple linked list implementation that uses Elements and a List",
-  "authors": [],
+  "authors": [
+    "vosechu"
+  ],
+  "contributors": [
+    "alxndr",
+    "budmc29",
+    "cadwallion",
+    "copiousfreetime",
+    "dkinzer",
+    "etrepum",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "tryantwit",
+    "zvkemp"
+  ],
   "files": {
     "solution": [
       "simple_linked_list.rb"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "ajwann",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "monkbroc",
+    "NeimadTL",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "space_age.rb"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -13,7 +13,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "monkbroc",
     "NeimadTL",
     "tryantwit"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "pendletons",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "strain.rb"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -10,7 +10,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "pendletons",
     "tryantwit"
   ],

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "ajwann",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "etmoore",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "julianandrews",
+    "kotp",
+    "mambocab",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "sum_of_multiples.rb"

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -15,7 +15,6 @@
     "jpotts244",
     "julianandrews",
     "kotp",
-    "mambocab",
     "tryantwit"
   ],
   "files": {

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Tally the results of a small football competition.",
-  "authors": [],
+  "authors": [
+    "gchan"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "ccouzens",
+    "emcoding",
+    "hilary",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "tournament.rb"

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,6 +1,22 @@
 {
   "blurb": "Take input text and output it transposed.",
-  "authors": [],
+  "authors": [
+    "gchan"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "ccouzens",
+    "emcoding",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jbergenson",
+    "jpotts244",
+    "kotp",
+    "pgaspar",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "transpose.rb"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -13,7 +13,6 @@
     "Insti",
     "jpotts244",
     "kotp",
-    "mambocab",
     "Pavling",
     "securitylater",
     "tryantwit"

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "durrellchamorro",
+    "favrik",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "mambocab",
+    "Pavling",
+    "securitylater",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "triangle.rb"

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -11,7 +11,6 @@
     "iHiD",
     "Insti",
     "kotp",
-    "mambocab",
     "nathanbwright",
     "tryantwit"
   ],

--- a/exercises/practice/trinary/.meta/config.json
+++ b/exercises/practice/trinary/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Convert a trinary number, represented as a string (e.g. '102012'), to its decimal equivalent using first principles.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "haus",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kotp",
+    "mambocab",
+    "nathanbwright",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "trinary.rb"

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "alexpchin",
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "kenliu",
+    "kickinbahk",
+    "kotp",
+    "mambocab",
+    "PatrickMcSweeny",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "twelve_days.rb"

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -14,7 +14,6 @@
     "kenliu",
     "kickinbahk",
     "kotp",
-    "mambocab",
     "PatrickMcSweeny",
     "tryantwit"
   ],

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
-  "authors": [],
+  "authors": [
+    "repinel"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kvsm",
+    "kytrinyx",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "two_bucket.rb"

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": [],
+  "authors": [
+    "architapatelis"
+  ],
+  "contributors": [
+    "cadwallion",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "two_fer.rb"

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,6 +1,24 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "claytonflesher",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jmay",
+    "jpotts244",
+    "kickinbahk",
+    "kotp",
+    "mambocab",
+    "pvcarrera",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "word_count.rb"

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -15,7 +15,6 @@
     "jpotts244",
     "kickinbahk",
     "kotp",
-    "mambocab",
     "pvcarrera",
     "tryantwit"
   ],

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,6 +1,24 @@
 {
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
-  "authors": [],
+  "authors": [
+    "vosechu"
+  ],
+  "contributors": [
+    "budmc29",
+    "cadwallion",
+    "dkinzer",
+    "hilary",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "kytrinyx",
+    "mambocab",
+    "pgaspar",
+    "srabuini",
+    "tommyschaefer",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "wordy.rb"

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -13,7 +13,6 @@
     "jpotts244",
     "kotp",
     "kytrinyx",
-    "mambocab",
     "pgaspar",
     "srabuini",
     "tommyschaefer",

--- a/exercises/practice/zipper/.meta/config.json
+++ b/exercises/practice/zipper/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Creating a zipper for a binary tree.",
-  "authors": [],
+  "authors": [
+    "tuxagon"
+  ],
+  "contributors": [
+    "cadwallion",
+    "iHiD",
+    "Insti",
+    "jpotts244",
+    "kotp",
+    "tryantwit"
+  ],
   "files": {
     "solution": [
       "zipper.rb"


### PR DESCRIPTION
With v3, we've introduced the idea of exercise authors and contributors. This information is stored in the exercise's `.meta/config.json` file (see [the docs](https://github.com/exercism/docs/blob/main/anatomy/tracks/practice-exercises.md#file-metaconfigjson)).

Concept Exercises, which are all new, have all defined their authors and contributors. Practice Exercises though are missing this information. In this PR, we attempt to populate the authors and contributors of Practice Exercises based on their commit history.

## Algorithm

We start out by looking at the current Practice Exercises. For each Practice Exercise, we'll look at the commit history of its files to see which commits did something with that Practice Exercise. How renames are handled is discussed in the "Renames" section later in this document. 

Each commit that we can link to a Practice Exercise will be used to determine authorship/contributorship. Here is how we assign authorship/contributorship:

### Authors

1. Find the Git commit author of the oldest commit linked to that Practice Exercise. As there can only be one oldest commit, we only have one author
2. Find the GitHub username for the Git commit author of that commit
3. Add the GitHub username of the Git commit author to the `authors` key in the `.meta/config.json` file

### Contributors

1. Find the Git commit authors of all but the oldest commit linked to that Practice Exercise. If there is only one commit, there won't be any contributors.
1. Exclude the Git commit author of the oldest commit from the list of Git commit authors (an author is _not_ also a contributor) 
2. Find the GitHub usernames for the Git commit authors of those commits
3. Add the GitHub usernames of the Git commit authors to the `contributor` key in the `.meta/config.json` file

We're using the GitHub GraphQL API to find the username of a commit author. In some cases though, a username cannot be found for a commit (e.g. due to the user account no longer existing), in which case we'll skip the commit. 

## Renames

There is a select number of Practice Exercises that might have been renamed at some point. You can ask Git to "follow" a file over its renames using `git log --follow <file>`, which will also return commits made before renames. Unfortunately, Git does not store renames, it just stores the contents of the renamed files and tries to guess if a file was renamed by looking at its contents. This _can_ (and will) lead to false positives, where Git will think a file has been renamed whereas it hasn't. As we don't want to have incorrect authors/contributors for exercises, we're ignoring renames. The only exception to this are known exercise renames:

- `bracket-push` was renamed to `matching-brackets`
- `retree` was renamed to `satellite`
- `resistor-colors` was renamed to `resistor-color-duo`
- `kindergarden-garden` was renamed to `kindergarten-garden`

If you know of a rename of a Practice Exercise, please check to see if its authors and contributors are correctly set.

## Exclusions

There are some commits that we skip over, which thus don't influence the authors/contributors list:

- Commits authored by `dependabot[bot]`, `dependabot-preview[bot]` or `github-actions[bot]`
- Bulk update PRs made by `ErikSchierboom` or `kytrinx` to update the track

## Maintainer TODO list

These are the things you, the maintainers, should do:

- Check the authors and contributors, adding/removing users where the data is missing or incorrect
- Double-check any renamed Practice Exercises
- Check for Practice Exercises with missing authors, which is most likely due to the author not being on GitHub anymore 
- Add additional authors if you know that a Practice Exercise has actually been created by more than one author 

If you find something needs updating, just push a new commit to this PR.

## Tracking

https://github.com/exercism/v3-launch/issues/24